### PR TITLE
sketch of AB testing

### DIFF
--- a/app/scripts/lib/ab.js
+++ b/app/scripts/lib/ab.js
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+define([
+  'lib/storage'
+  ], function (Storage) {
+
+  function AB() {
+    this._storage = new Storage(localStorage);
+    this._roll = this._getRoll();
+    this._experiments = {};
+    this._data = {};
+  }
+
+  AB.prototype = {
+    _getRoll: function () {
+      var roll = this._storage.get('roll');
+      if (!roll) {
+        var rand = new Uint32Array(1);
+        crypto.getRandomValues(rand);
+        roll = rand[0];
+        this._storage.set('roll', roll);
+      }
+      return roll;
+    },
+    isEnabled: function (name) {
+      var enabled = this._experiments[name] !== false;
+      this._data[name] = enabled;
+      return enabled;
+    },
+    addExperiment: function (name, percentEnabled) {
+      this._experiments[name] = (this._roll % 100) < percentEnabled;
+    },
+    load: function (experiments) {
+      for (name in experiments) {
+        this.addExperiment(name, experiments[name]);
+      }
+    },
+    data: function () {
+      return this._data;
+    }
+  };
+
+  return new AB();
+});

--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -22,6 +22,7 @@ define([
   'backbone',
   'lib/promise',
   'router',
+  'lib/ab',
   'lib/translator',
   'lib/session',
   'lib/url',
@@ -49,6 +50,7 @@ function (
   Backbone,
   p,
   Router,
+  AB,
   Translator,
   Session,
   Url,
@@ -145,7 +147,7 @@ function (
                     .then(_.bind(this.initializeAuthenticationBroker, this))
                     // storage format upgrades depend on user
                     .then(_.bind(this.upgradeStorageFormats, this))
-
+                    .then(_.bind(this.initializeAB, this))
                     // metrics depends on the relier.
                     .then(_.bind(this.initializeMetrics, this))
                     // router depends on all of the above
@@ -156,6 +158,10 @@ function (
       this._config = config;
       this._configLoader.useConfig(config);
       Session.set('config', config);
+    },
+
+    initializeAB: function () {
+      AB.load(this._config.experiments);
     },
 
     initializeL10n: function () {

--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -22,8 +22,9 @@ define([
   'lib/xhr',
   'lib/promise',
   'lib/url',
-  'lib/strings'
-], function (_, Backbone, $, speedTrap, xhr, p, Url, Strings) {
+  'lib/strings',
+  'lib/ab'
+], function (_, Backbone, $, speedTrap, xhr, p, Url, Strings, AB) {
   'use strict';
 
   // Speed trap is a singleton, convert it
@@ -44,7 +45,8 @@ define([
     'marketingLink',
     'marketingType',
     'marketingClicked',
-    'screen'
+    'screen',
+    'ab'
   ];
 
   var TEN_MINS_MS = 10 * 60 * 1000;
@@ -140,7 +142,8 @@ define([
         entrypoint: this._entrypoint,
         marketingType: this._marketingType || 'none',
         marketingLink: this._marketingLink || 'none',
-        marketingClicked: this._marketingClicked || false
+        marketingClicked: this._marketingClicked || false,
+        ab: AB.data()
       }, loadData, unloadData);
 
       return allData;
@@ -258,5 +261,3 @@ define([
 
   return Metrics;
 });
-
-

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -16,10 +16,11 @@ define([
   'lib/validate',
   'views/mixins/service-mixin',
   'views/mixins/avatar-mixin',
-  'views/decorators/progress_indicator'
+  'views/decorators/progress_indicator',
+  'lib/ab'
 ],
 function (_, p, BaseView, FormView, SignInTemplate, Session, PasswordMixin,
-      AuthErrors, Validate, ServiceMixin, AvatarMixin, showProgressIndicator) {
+      AuthErrors, Validate, ServiceMixin, AvatarMixin, showProgressIndicator, AB) {
   var t = BaseView.t;
 
   var View = FormView.extend({

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -14,10 +14,11 @@ define([
   'lib/auth-errors',
   'lib/strings',
   'views/mixins/password-mixin',
-  'views/mixins/service-mixin'
+  'views/mixins/service-mixin',
+  'lib/ab'
 ],
 function (_, p, BaseView, FormView, Template, Session, AuthErrors,
-      Strings, PasswordMixin, ServiceMixin) {
+      Strings, PasswordMixin, ServiceMixin, AB) {
   var t = BaseView.t;
 
   function selectAutoFocusEl(bouncedEmail, email, password) {

--- a/server/lib/metrics-collector-stderr.js
+++ b/server/lib/metrics-collector-stderr.js
@@ -104,7 +104,8 @@ function toLoggableEvent(event) {
     'service',
     'marketingLink',
     'marketingType',
-    'marketingClicked'
+    'marketingClicked',
+    'ab'
   ], loggableEvent, event);
 
   addNavigationTiming(loggableEvent, event);

--- a/server/lib/routes/get-config.js
+++ b/server/lib/routes/get-config.js
@@ -71,10 +71,10 @@ module.exports = function (i18n) {
       oauthClientId: clientId,
       // req.lang is set by abide in a previous middleware.
       language: req.lang,
-      metricsSampleRate: config.get('metrics.sample_rate')
+      metricsSampleRate: config.get('metrics.sample_rate'),
+      experiments: { foo: 25 }
     });
   };
 
   return route;
 };
-


### PR DESCRIPTION
This is a minimal client-side AB testing implementation to poke at and experiment with. I tried not to make too many decisions about what features should or shouldn't be included and focused on the mechanics of making it functional.
## Points of interest
- `AB` is a singleton initialized in `app-start.js` and required by any file that needs it
- the browser loads (from local storage) or creates a random `roll` variable for use in "anonymous" tests
  - `roll` allows consistent choices between browser sessions
- experiments are delivered to the browser via the `/config` endpoint
  - this was only for my convenience to minimize the diff but it _may_ be a good place anyway(?)
  - experiments default to `enabled` if the name isn't found in the config
- experiments only define a `name` and an `percentEnabled` for now
- results are reported to the `/metrics` endpoint
  - also chosen to minimize the diff. It may or may not be where we want the data sent
  - the `ab` data only includes results for experiments that were activated by an `isEnabled` check
  - the results only include whether an experiment was enabled for now

So, lots of choices still to make, but this sort of does something ;)

f? @shane-tomlinson @ckarlof
